### PR TITLE
Ajuste de timeout do Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   testMatch: ["**/__tests__/**/*.test.js"],
+  testTimeout: 10000, // Nativamente, o Jest tem um timeout de 5s e estava quebrando alguns testes
   reporters: [
     'default',
     ['jest-html-reporter', {


### PR DESCRIPTION
Ajuste no timeout do Jest. Estava quebrando alguns cenários por conta de timeout e se fez necessário aumentar esse tempo.